### PR TITLE
Add SVG mask for hero section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **logos** Added Pocket logo
 * **icons** Added menu panel arrow icon
+* **backgrounds** Added hero curve SVG mask
 
 # 0.0.4
 

--- a/backgrounds/masks/hero/hero-curve.svg
+++ b/backgrounds/masks/hero/hero-curve.svg
@@ -1,0 +1,3 @@
+<svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path d="M0,100 C20,30 40,0 60,0 C75,0 90,10 100,25 L100,100 L0,100 Z" fill="#d8d8d8" />
+</svg>


### PR DESCRIPTION
Adds a new folder for masks. This is needed for the hero section but I can imagine using masks in other places too.